### PR TITLE
fix(exception) Hoa Group

### DIFF
--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -155,8 +155,12 @@ class Server
                 }
 
                 if ($exception instanceof Group) {
-
-                    if (0 === $exception->getStackSize()) {
+                    try {
+                        // Handle the error of HOA on group variable NULL first send event
+                        if (0 === $exception->getStackSize()) {
+                            return;
+                        }
+                    } catch (\Throwable $throwable) {
                         return;
                     }
 


### PR DESCRIPTION
The `getStackSize` method return NULL. This cause PHP FATAL.

When the `Group` class are initialized, the event are sent through the `parent` before the `_group` variable have any chance to be initialized.

Dirty try catch implement to avoid this FATAL